### PR TITLE
Merge 0.160 release branch into main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debian-analyzer"
-version = "0.160.14"
+version = "0.160.15"
 authors = [ "Jelmer Vernooij <jelmer@jelmer.uk>"]
 edition = "2021"
 license = "GPL-2.0+"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debian-analyzer"
-version = "0.160.15"
+version = "0.160.16"
 authors = [ "Jelmer Vernooij <jelmer@jelmer.uk>"]
 edition = "2021"
 license = "GPL-2.0+"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,8 +609,7 @@ mod tests {
         use breezyshim::tree::MutableTree;
 
         let td = tempfile::tempdir().unwrap();
-        let tree =
-            create_standalone_workingtree(td.path(), &ControlDirFormat::default()).unwrap();
+        let tree = create_standalone_workingtree(td.path(), &ControlDirFormat::default()).unwrap();
         tree.build_commit()
             .message("init")
             .committer("Test <test@example.com>")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
             relpaths
                 .iter()
                 .filter_map(|p| {
-                    if local_tree.has_filename(p) && local_tree.is_ignored(p).is_some() {
+                    if local_tree.has_filename(p) && local_tree.is_ignored(p).is_none() {
                         Some(p.as_path())
                     } else {
                         None
@@ -598,5 +598,43 @@ mod tests {
             Some(Certainty::Possible),
             min_certainty(&[Certainty::Likely, Certainty::Certain, Certainty::Possible])
         );
+    }
+
+    #[test]
+    fn test_apply_or_revert_dirty_tracker_adds_new_files() {
+        // With a DirtyTreeTracker active, apply_or_revert must add newly
+        // created (untracked, unignored) files to the working tree.
+        use breezyshim::controldir::{create_standalone_workingtree, ControlDirFormat};
+        use breezyshim::dirty_tracker::DirtyTreeTracker;
+        use breezyshim::tree::MutableTree;
+
+        let td = tempfile::tempdir().unwrap();
+        let tree =
+            create_standalone_workingtree(td.path(), &ControlDirFormat::default()).unwrap();
+        tree.build_commit()
+            .message("init")
+            .committer("Test <test@example.com>")
+            .allow_pointless(true)
+            .commit()
+            .unwrap();
+
+        let basis_tree = tree.basis_tree().unwrap();
+        let mut tracker = Some(DirtyTreeTracker::new(Clone::clone(&tree)));
+
+        let lock = tree.lock_write().unwrap();
+        apply_or_revert(
+            &tree,
+            std::path::Path::new(""),
+            &basis_tree,
+            tracker.as_mut(),
+            |basedir| -> Result<(), ()> {
+                std::fs::write(basedir.join("foo"), "bar").unwrap();
+                Ok(())
+            },
+        )
+        .unwrap_or_else(|_| panic!("expected changes for newly created file"));
+        std::mem::drop(lock);
+
+        assert!(tree.is_versioned(std::path::Path::new("foo")));
     }
 }

--- a/src/maintscripts.rs
+++ b/src/maintscripts.rs
@@ -310,7 +310,10 @@ enum Line {
 impl std::fmt::Display for Line {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Line::Comment(comment) => write!(f, "# {}", comment),
+            // Comment lines are stored verbatim by FromStr (with their
+            // leading `#` and any blank lines kept as-is); write them back
+            // unchanged.
+            Line::Comment(comment) => write!(f, "{}", comment),
             Line::Entry(entry) => write!(f, "{}", entry),
         }
     }
@@ -350,21 +353,26 @@ impl Maintscript {
             .collect()
     }
 
-    /// Remove an entry from the maintscript file
+    /// Remove the entry at `index` (where `index` is an index into the
+    /// list returned by [`Self::entries`]). Any contiguous comment or
+    /// blank lines immediately preceding the entry are removed too.
     pub fn remove(&mut self, index: usize) {
-        // Also remove preceding comments
-        let mut comments = vec![];
+        let mut comments: Vec<usize> = vec![];
+        let mut entries_seen = 0usize;
         for (i, line) in self.lines.iter().enumerate() {
             match line {
                 Line::Comment(_) => comments.push(i),
                 Line::Entry(_) => {
-                    if i == index {
-                        for i in comments.iter().rev() {
-                            self.lines.remove(*i);
+                    if entries_seen == index {
+                        // Remove preceding comments (in descending index
+                        // order) plus the entry itself.
+                        for c in comments.iter().rev() {
+                            self.lines.remove(*c);
                         }
-                        self.lines.remove(index - comments.len());
+                        self.lines.remove(i - comments.len());
                         return;
                     }
+                    entries_seen += 1;
                     comments.clear();
                 }
             }
@@ -443,5 +451,27 @@ dir_to_symlink /etc/foo /etc/bar 1.2.3-4";
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_round_trip_preserves_comments() {
+        let original = "# leading comment\nrm_conffile /etc/foo.conf 1.2.3-4\n# trailing comment";
+        let parsed = original.parse::<super::Maintscript>().unwrap();
+        assert_eq!(parsed.to_string(), original);
+    }
+
+    #[test]
+    fn test_round_trip_preserves_blank_lines() {
+        let original = "rm_conffile /etc/foo.conf 1.2.3-4\n\nrm_conffile /etc/bar.conf 1.2.3-4";
+        let parsed = original.parse::<super::Maintscript>().unwrap();
+        assert_eq!(parsed.to_string(), original);
+    }
+
+    #[test]
+    fn test_remove_drops_preceding_comments() {
+        let original = "# comment for foo\nrm_conffile /etc/foo.conf 1.2.3-4\nrm_conffile /etc/bar.conf 1.2.3-4";
+        let mut parsed = original.parse::<super::Maintscript>().unwrap();
+        parsed.remove(0);
+        assert_eq!(parsed.to_string(), "rm_conffile /etc/bar.conf 1.2.3-4");
     }
 }


### PR DESCRIPTION
Merges the 0.160 maintenance branch into main, including release 0.160.15.

Changes since main diverged:
- maintscripts: Fix Display round-trip and entry-index lookup (ffbed2f0)
- Release 0.160.15 (a4dbc626)

Note: main has been restructured into a workspace (debian-workbench + debian-analyzer) since 0.160 was branched, so this merge may need conflict resolution.